### PR TITLE
[디자인 수정사항 반영(2)]

### DIFF
--- a/src/config/menu.config.tsx
+++ b/src/config/menu.config.tsx
@@ -367,7 +367,7 @@ export const MENU_SIDEBAR: TMenuConfig = [
         path: '/admin/cash'
       },
       {
-        title: '설정 관리',
+        title: '캐시 설정',
         icon: 'dollar text-warning',
         path: '/admin/cash_setting'
       }

--- a/src/config/roles.config.ts
+++ b/src/config/roles.config.ts
@@ -110,7 +110,7 @@ export const USER_ROLE_THEME_COLORS: Record<string, RoleThemeColors> = {
     transparent: 'bg-indigo-50'
   },
 
-  // 유통사 테마 색상 (호박색 계열)
+  // 총판 테마 색상 (호박색 계열)
   [USER_ROLES.DISTRIBUTOR]: {
     base: 'bg-amber-600',
     gradient: 'bg-gradient-to-r from-amber-500 to-orange-600',

--- a/src/pages/admin/LevelUpRequestsPage.tsx
+++ b/src/pages/admin/LevelUpRequestsPage.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+import ReactDOM from 'react-dom';
 import { CommonTemplate } from '@/components/pageTemplate';
 import { KeenIcon } from '@/components';
 import { LevelupApply } from '@/types/business';
@@ -12,6 +13,112 @@ type RequestWithUser = LevelupApply & {
     full_name: string;
     business: any;
   }
+};
+
+// 이미지 모달 컴포넌트 분리
+const ImageModal = ({ 
+  isOpen, 
+  imageUrl, 
+  onClose 
+}: { 
+  isOpen: boolean; 
+  imageUrl: string; 
+  onClose: () => void;
+}) => {
+  // 모달이 닫혀 있으면 렌더링하지 않음
+  if (!isOpen) return null;
+
+  // document.body에 포털로 렌더링
+  return ReactDOM.createPortal(
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black/80"
+      onClick={onClose} // 배경 클릭 시 모달 닫기
+      style={{ 
+        position: 'fixed', 
+        top: 0, 
+        left: 0, 
+        right: 0, 
+        bottom: 0,
+        zIndex: 9999,
+        width: '100vw',
+        height: '100vh'
+      }}
+    >
+      <div
+        className="relative max-w-4xl w-full max-h-[90vh] overflow-auto bg-white rounded-lg p-1 m-4"
+        onClick={(e) => e.stopPropagation()} // 모달 내부 클릭 시 이벤트 전파 방지
+        style={{
+          position: 'relative',
+          zIndex: 10000
+        }}
+      >
+        {/* 우측 상단 닫기 버튼 */}
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 z-10 bg-red-600 hover:bg-red-700 text-white rounded-full w-10 h-10 flex items-center justify-center shadow-lg transition-all"
+          aria-label="닫기"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+        
+        {/* 상단 닫기 텍스트 배너 */}
+        <div className="bg-gray-800/90 text-white py-2 px-4 text-center mb-2">
+          <button
+            onClick={onClose}
+            className="flex items-center justify-center w-full"
+          >
+            <span>사업자등록증 이미지 (클릭하여 닫기)</span>
+            <div className="ml-2 inline-flex">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+          </button>
+        </div>
+
+        <div className="flex justify-center">
+          <img
+            src={imageUrl}
+            alt="사업자등록증"
+            className="max-h-[70vh] object-contain"
+            style={{
+              maxWidth: '100%'
+            }}
+            onError={(e) => {
+              (e.target as HTMLImageElement).src = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDUwMCA1MDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3Qgd2lkdGg9IjUwMCIgaGVpZ2h0PSI1MDAiIGZpbGw9IiNFQkVCRUIiLz48dGV4dCB4PSIxNTAiIHk9IjI1MCIgZm9udC1mYW1pbHk9IkFyaWFsIiBmb250LXNpemU9IjI0IiBmaWxsPSIjNjY2NjY2Ij7snbTrr7jsp4Drk6TsnZgg67Cc7IOd7J2EIOyeheugpe2VqeyzkuycvOuhnDwvdGV4dD48L3N2Zz4=";
+            }}
+          />
+        </div>
+
+        <div className="flex justify-center items-center gap-4 mt-4 pb-2">
+          <a
+            href={imageUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn-success flex items-center"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+            <span>새 탭에서 열기</span>
+          </a>
+
+          <button
+            onClick={onClose}
+            className="btn btn-danger flex items-center"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            <span>닫기</span>
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
 };
 
 const LevelUpRequestsPage = () => {
@@ -184,6 +291,7 @@ const LevelUpRequestsPage = () => {
     }
   };
   
+  // 초기 데이터 로드
   useEffect(() => {
     fetchRequests();
   }, []);
@@ -344,6 +452,14 @@ const LevelUpRequestsPage = () => {
           )}
         </div>
       </div>
+      
+      {/* 이미지 모달은 분리된 컴포넌트로 사용 */}
+      <ImageModal 
+        isOpen={imageModalOpen}
+        imageUrl={selectedImage}
+        onClose={() => setImageModalOpen(false)}
+      />
+      
       {/* 거부 사유 입력 모달 */}
       <RejectReasonModal
         open={isRejectModalOpen}
@@ -359,77 +475,6 @@ const LevelUpRequestsPage = () => {
         message={statusModalProps.message}
         status={statusModalProps.status}
       />
-      
-      {/* 이미지 확대 모달 */}
-      {imageModalOpen && (
-        <div 
-          className="fixed inset-0 flex items-center justify-center z-50 bg-black/70"
-          onClick={() => setImageModalOpen(false)} // 배경 클릭 시 모달 닫기
-        >
-          <div 
-            className="relative max-w-4xl max-h-[90vh] overflow-auto bg-white rounded-lg p-1"
-            onClick={(e) => e.stopPropagation()} // 모달 내부 클릭 시 이벤트 전파 방지
-          >
-            {/* 우측 상단 닫기 버튼 */}
-            <button
-              onClick={() => setImageModalOpen(false)}
-              className="absolute top-3 right-3 z-10 bg-red-600 hover:bg-red-700 text-white rounded-full w-10 h-10 flex items-center justify-center shadow-lg transition-all"
-              aria-label="닫기"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-            
-            {/* 상단 닫기 텍스트 배너 */}
-            <div className="bg-gray-800/80 text-white py-2 px-4 text-center mb-2">
-              <button 
-                onClick={() => setImageModalOpen(false)}
-                className="flex items-center justify-center w-full"
-              >
-                <span>이미지 닫기</span>
-                <div className="ml-2 inline-flex">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </div>
-              </button>
-            </div>
-            <img 
-              src={selectedImage} 
-              alt="사업자등록증" 
-              className="max-h-[85vh] object-contain"
-              onError={(e) => {
-                
-                (e.target as HTMLImageElement).src = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDUwMCA1MDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3Qgd2lkdGg9IjUwMCIgaGVpZ2h0PSI1MDAiIGZpbGw9IiNFQkVCRUIiLz48dGV4dCB4PSIxNTAiIHk9IjI1MCIgZm9udC1mYW1pbHk9IkFyaWFsIiBmb250LXNpemU9IjI0IiBmaWxsPSIjNjY2NjY2Ij7snbTrr7jsp4Drk6TsnZgg67Cc7IOd7J2EIOyeheugpe2VqeyzkuycvOuhnDwvdGV4dD48L3N2Zz4=";
-              }}
-            />
-            <div className="flex justify-center items-center gap-4 mt-3 pb-2">
-              <button 
-                onClick={() => setImageModalOpen(false)}
-                className="btn btn-danger flex items-center"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-                <span>닫기</span>
-              </button>
-              
-              <a 
-                href={selectedImage} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="btn btn-outline-primary flex items-center"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                </svg>
-                <span>새 탭에서 열기</span>
-              </a>
-            </div>
-          </div>
-        </div>
-      )}
     </CommonTemplate>
   );
 };

--- a/src/pages/admin/UsersPage.tsx
+++ b/src/pages/admin/UsersPage.tsx
@@ -3,7 +3,7 @@ import { CommonTemplate } from '@/components/pageTemplate';
 import { KeenIcon } from '@/components';
 import { supabase } from '@/supabase';
 import { AdminUserModal } from './block/AdminUserModal';
-import { USER_ROLES, USER_ROLE_BADGE_COLORS, getRoleBadgeColor, getRoleDisplayName, getRoleThemeColors } from '@/config/roles.config';
+import { USER_ROLES, USER_ROLE_BADGE_COLORS, USER_ROLE_THEME_COLORS, getRoleBadgeColor, getRoleDisplayName, getRoleThemeColors, RoleThemeColors } from '@/config/roles.config';
 
 const MakeUserRow = (user: any) => {
     const [userModalOpen, setUserModalOpen] = useState<boolean>(false);
@@ -15,14 +15,34 @@ const MakeUserRow = (user: any) => {
     const closeUserModalOpen = () => setUserModalOpen(false);
 
     const renderRoleBadge = (role: string): { name: string, class: string, style?: React.CSSProperties } => {
-        const themeColors = getRoleThemeColors(role);
+        // 기본 스타일 설정
+        const baseStyle: React.CSSProperties = {
+            backgroundColor: '#e5e7eb15', // 기본 배경색 (회색 10%)
+            color: '#6b7280' // 기본 텍스트 색상 (회색)
+        };
+
+        try {
+            // USER_ROLE_THEME_COLORS에서 직접 가져오기
+            const roleTheme = USER_ROLE_THEME_COLORS[role];
+            if (roleTheme && roleTheme.baseHex) {
+                return {
+                    name: getRoleDisplayName(role),
+                    class: `bg-${getRoleBadgeColor(role)}/10 text-${getRoleBadgeColor(role)}`,
+                    style: {
+                        backgroundColor: `${roleTheme.baseHex}15`, /* 10% 투명도 */
+                        color: roleTheme.baseHex
+                    }
+                };
+            }
+        } catch (error) {
+            // 에러 처리 - 기본값 사용
+        }
+
+        // 기본값 반환
         return {
             name: getRoleDisplayName(role),
             class: `bg-${getRoleBadgeColor(role)}/10 text-${getRoleBadgeColor(role)}`,
-            style: {
-                backgroundColor: `${themeColors.baseHex}15`, /* 10% 투명도 */
-                color: themeColors.baseHex
-            }
+            style: baseStyle
         };
     }
 
@@ -506,7 +526,7 @@ const UsersPage = () => {
                                                                 {(() => {
                                                                     return (
                                                                         <p className="font-medium" style={{
-                                                                    color: getRoleThemeColors(user.role).baseHex
+                                                                    color: USER_ROLE_THEME_COLORS[user.role]?.baseHex || '#6b7280'
                                                                 }}>{getRoleDisplayName(user.role)}</p>
                                                                     );
                                                                 })()}

--- a/src/pages/admin/UsersPage.tsx
+++ b/src/pages/admin/UsersPage.tsx
@@ -3,7 +3,7 @@ import { CommonTemplate } from '@/components/pageTemplate';
 import { KeenIcon } from '@/components';
 import { supabase } from '@/supabase';
 import { AdminUserModal } from './block/AdminUserModal';
-import { USER_ROLES, USER_ROLE_BADGE_COLORS, getRoleBadgeColor, getRoleDisplayName } from '@/config/roles.config';
+import { USER_ROLES, USER_ROLE_BADGE_COLORS, getRoleBadgeColor, getRoleDisplayName, getRoleThemeColors } from '@/config/roles.config';
 
 const MakeUserRow = (user: any) => {
     const [userModalOpen, setUserModalOpen] = useState<boolean>(false);
@@ -14,10 +14,15 @@ const MakeUserRow = (user: any) => {
     // 회원 정보 모달 닫기
     const closeUserModalOpen = () => setUserModalOpen(false);
 
-    const renderRoleBadge = (role: string): { name: string, class: string } => {
+    const renderRoleBadge = (role: string): { name: string, class: string, style?: React.CSSProperties } => {
+        const themeColors = getRoleThemeColors(role);
         return {
             name: getRoleDisplayName(role),
-            class: `text-${getRoleBadgeColor(role)}`
+            class: `bg-${getRoleBadgeColor(role)}/10 text-${getRoleBadgeColor(role)}`,
+            style: {
+                backgroundColor: `${themeColors.baseHex}15`, /* 10% 투명도 */
+                color: themeColors.baseHex
+            }
         };
     }
 
@@ -69,8 +74,12 @@ const MakeUserRow = (user: any) => {
                     </div>
                 </td>
                 <td className="py-4 px-5">
-                    <span className={`inline-flex px-3 py-1 text-xs font-medium rounded-full ${renderRoleBadge(user.user.role)?.class}`}>{renderRoleBadge(user.user.role)?.name}</span>
-
+                    <span
+                        className={`inline-flex px-3 py-1 text-xs font-medium rounded-full ${renderRoleBadge(user.user.role)?.class}`}
+                        style={renderRoleBadge(user.user.role)?.style}
+                    >
+                        {renderRoleBadge(user.user.role)?.name}
+                    </span>
                 </td>
                 <td className="py-4 px-5">
                     {renderStatusBadge(user.user.status)}
@@ -496,7 +505,9 @@ const UsersPage = () => {
                                                                 </div>
                                                                 {(() => {
                                                                     return (
-                                                                        <p className={`font-medium text-${getRoleBadgeColor(user.role)}`}>{getRoleDisplayName(user.role)}</p>
+                                                                        <p className="font-medium" style={{
+                                                                    color: getRoleThemeColors(user.role).baseHex
+                                                                }}>{getRoleDisplayName(user.role)}</p>
                                                                     );
                                                                 })()}
                                                             </div>

--- a/src/pages/admin/cash/ManageCashPage.tsx
+++ b/src/pages/admin/cash/ManageCashPage.tsx
@@ -375,7 +375,7 @@ const ManageCashPage = () => {
                         <tr className="border-b border-border bg-muted">
                           <th className="py-4 px-5 text-start">
                             <div className="flex items-center">
-                              <input type="checkbox" className="checkbox checkbox-sm checkbox-primary" />
+                              <input type="checkbox" className="input checkbox checkbox-sm checkbox-primary" />
                             </div>
                           </th>
                           <th className="py-4 px-5 text-start min-w-[120px]">
@@ -419,7 +419,7 @@ const ManageCashPage = () => {
                             <tr key={index} className="border-b border-border hover:bg-muted/40">
                               <td className="py-4 px-5">
                                 <div className="flex items-center">
-                                  <input type="checkbox" className="checkbox checkbox-sm checkbox-primary" />
+                                  <input type="checkbox" className="input checkbox checkbox-sm checkbox-primary" />
                                 </div>
                               </td>
                               <td className="py-4 px-5">
@@ -503,7 +503,7 @@ const ManageCashPage = () => {
                         <div key={index} className="p-4 hover:bg-muted/40">
                           <div className="flex items-center justify-between mb-3">
                             <div className="flex items-center">
-                              <input type="checkbox" className="checkbox checkbox-sm checkbox-primary mr-3" />
+                              <input type="checkbox" className="input checkbox checkbox-sm checkbox-primary mr-3" />
                               <div className="size-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold mr-2">
                                 {request.full_name ? request.full_name.charAt(0) : '?'}
                               </div>

--- a/src/pages/admin/cash/ManageSettingPage.tsx
+++ b/src/pages/admin/cash/ManageSettingPage.tsx
@@ -407,7 +407,7 @@ const ManageSettingPage = () => {
                     <input
                       type="text"
                       placeholder="예: 1,000,000"
-                      className="pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
+                      className="input pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
                       value={globalSettings.min_request_amount.toLocaleString()}
                       onChange={(e) => {
                         // 입력에서 콤마를 제거하고 숫자만 파싱
@@ -440,7 +440,7 @@ const ManageSettingPage = () => {
                     <input
                       type="number"
                       placeholder="예: 10"
-                      className="block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-12"
+                      className="input block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-12"
                       value={globalSettings.free_cash_percentage}
                       onChange={(e) => setGlobalSettings({ ...globalSettings, free_cash_percentage: parseInt(e.target.value) || 0 })}
                       min="0"
@@ -474,7 +474,7 @@ const ManageSettingPage = () => {
                     <input
                       type="number"
                       placeholder="예: 1"
-                      className="block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-16"
+                      className="input block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-16"
                       value={globalSettings.expiry_months}
                       onChange={(e) => setGlobalSettings({ ...globalSettings, expiry_months: parseInt(e.target.value) || 0 })}
                       min="0"
@@ -513,7 +513,7 @@ const ManageSettingPage = () => {
                     <input
                       type="text"
                       placeholder="예: 10,000"
-                      className="pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
+                      className="input pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
                       value={globalSettings.min_usage_amount.toLocaleString()}
                       onChange={(e) => {
                         // 입력에서 콤마를 제거하고 숫자만 파싱
@@ -546,7 +546,7 @@ const ManageSettingPage = () => {
                     <input
                       type="number"
                       placeholder="예: 5"
-                      className="block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-12"
+                      className="input block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-12"
                       value={globalSettings.min_usage_percentage}
                       onChange={(e) => setGlobalSettings({ ...globalSettings, min_usage_percentage: parseInt(e.target.value) || 0 })}
                       min="0"
@@ -635,7 +635,7 @@ const ManageSettingPage = () => {
                       <input
                         type="text"
                         placeholder="이메일로 사용자 검색..."
-                        className="pl-10 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
+                        className="input pl-10 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
                         value={searchUserEmail}
                         onChange={(e) => setSearchUserEmail(e.target.value)}
                         onFocus={() => setShowUserSearch(true)}
@@ -694,7 +694,7 @@ const ManageSettingPage = () => {
                               </div>
                               <input
                                 type="text"
-                                className="pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
+                                className="input pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
                                 value={userSetting.min_request_amount.toLocaleString()}
                                 onChange={(e) => {
                                   const value = e.target.value.replace(/,/g, '');
@@ -724,7 +724,7 @@ const ManageSettingPage = () => {
                             <div className="relative">
                               <input
                                 type="number"
-                                className="block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-8"
+                                className="input block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-8"
                                 value={userSetting.free_cash_percentage}
                                 onChange={(e) => setUserSetting({ ...userSetting, free_cash_percentage: parseInt(e.target.value) || 0 })}
                                 min="0"
@@ -758,7 +758,7 @@ const ManageSettingPage = () => {
                             <div className="relative">
                               <input
                                 type="number"
-                                className="block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-12"
+                                className="input block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-12"
                                 value={userSetting.expiry_months}
                                 onChange={(e) => setUserSetting({ ...userSetting, expiry_months: parseInt(e.target.value) || 0 })}
                                 min="0"
@@ -790,7 +790,7 @@ const ManageSettingPage = () => {
                             <div className="relative">
                               <input
                                 type="number"
-                                className="block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-8"
+                                className="input block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-8"
                                 value={userSetting.min_usage_percentage}
                                 onChange={(e) => setUserSetting({ ...userSetting, min_usage_percentage: parseInt(e.target.value) || 0 })}
                                 min="0"
@@ -826,7 +826,7 @@ const ManageSettingPage = () => {
                             </div>
                             <input
                               type="text"
-                              className="pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
+                              className="input pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary"
                               value={userSetting.min_usage_amount.toLocaleString()}
                               onChange={(e) => {
                                 const value = e.target.value.replace(/,/g, '');
@@ -843,7 +843,7 @@ const ManageSettingPage = () => {
                             <div className="flex items-center h-5">
                               <input
                                 type="checkbox"
-                                className="h-4 w-4 text-primary border-gray-300 rounded focus:ring-primary"
+                                className="input h-4 w-4 text-primary border-gray-300 rounded focus:ring-primary"
                                 checked={userSetting.is_active}
                                 onChange={(e) => setUserSetting({ ...userSetting, is_active: e.target.checked })}
                               />

--- a/src/pages/admin/site/notification/components/UserSelectModal.tsx
+++ b/src/pages/admin/site/notification/components/UserSelectModal.tsx
@@ -4,7 +4,7 @@ import { KeenIcon } from '@/components/keenicons';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { USER_ROLES, getRoleDisplayName, getRoleBadgeColor, getRoleThemeColors } from '@/config/roles.config';
+import { USER_ROLES, USER_ROLE_THEME_COLORS, getRoleDisplayName, getRoleBadgeColor, getRoleThemeColors, RoleThemeColors } from '@/config/roles.config';
 
 interface User {
   id: string;
@@ -140,14 +140,32 @@ const UserSelectModal: React.FC<UserSelectModalProps> = ({ isOpen, onClose, onSe
   // 역할에 따른 테마 클래스 및 인라인 스타일
   const getRoleClasses = (role: string) => {
     const color = getRoleBadgeColor(role);
-    const themeColors = getRoleThemeColors(role);
+    // 기본 스타일 설정
+    const baseStyle: React.CSSProperties = {
+      backgroundColor: '#e5e7eb15', // 기본 배경색 (회색 10%)
+      color: '#6b7280' // 기본 텍스트 색상 (회색)
+    };
 
+    try {
+      // USER_ROLE_THEME_COLORS에서 직접 가져오기
+      const roleTheme = USER_ROLE_THEME_COLORS[role];
+      if (roleTheme && roleTheme.baseHex) {
+        return {
+          className: `bg-${color}/10 text-${color}`,
+          style: {
+            backgroundColor: `${roleTheme.baseHex}15`,
+            color: roleTheme.baseHex
+          }
+        };
+      }
+    } catch (error) {
+      // 에러 처리 - 기본값 사용
+    }
+
+    // 기본값 반환
     return {
       className: `bg-${color}/10 text-${color}`,
-      style: {
-        backgroundColor: `${themeColors.baseHex}15`,
-        color: themeColors.baseHex
-      }
+      style: baseStyle
     };
   };
 

--- a/src/pages/admin/site/notification/components/UserSelectModal.tsx
+++ b/src/pages/admin/site/notification/components/UserSelectModal.tsx
@@ -4,7 +4,7 @@ import { KeenIcon } from '@/components/keenicons';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { USER_ROLES, getRoleDisplayName, getRoleBadgeColor } from '@/config/roles.config';
+import { USER_ROLES, getRoleDisplayName, getRoleBadgeColor, getRoleThemeColors } from '@/config/roles.config';
 
 interface User {
   id: string;
@@ -137,10 +137,18 @@ const UserSelectModal: React.FC<UserSelectModalProps> = ({ isOpen, onClose, onSe
     }
   };
 
-  // 역할에 따른 아이콘 및 배경색 클래스
+  // 역할에 따른 테마 클래스 및 인라인 스타일
   const getRoleClasses = (role: string) => {
     const color = getRoleBadgeColor(role);
-    return `bg-${color}-100 dark:bg-${color}-900/40 text-${color}-800 dark:text-${color}-300`;
+    const themeColors = getRoleThemeColors(role);
+
+    return {
+      className: `bg-${color}/10 text-${color}`,
+      style: {
+        backgroundColor: `${themeColors.baseHex}15`,
+        color: themeColors.baseHex
+      }
+    };
   };
 
   // 선택 완료
@@ -313,7 +321,10 @@ const UserSelectModal: React.FC<UserSelectModalProps> = ({ isOpen, onClose, onSe
                             {user.email}
                           </td>
                           <td className="px-6 py-4">
-                            <span className={`inline-flex px-2.5 py-0.5 text-xs font-medium rounded-full ${getRoleClasses(user.role)}`}>
+                            <span
+                              className={`inline-flex px-2.5 py-0.5 text-xs font-medium rounded-full ${getRoleClasses(user.role).className}`}
+                              style={getRoleClasses(user.role).style}
+                            >
                               {getRoleDisplayName(user.role)}
                             </span>
                           </td>

--- a/src/pages/admin/withdraw/WithdrawApprovePage.tsx
+++ b/src/pages/admin/withdraw/WithdrawApprovePage.tsx
@@ -139,31 +139,31 @@ export const WithdrawApprovePage: React.FC = () => {
       description="관리자 메뉴 > 슬롯 관리 > 슬롯 승인 관리"
       showPageMenu={false}
     >
-      <div className="w-full max-w-full mx-auto px-4 sm:px-6 md:px-8">
-        <div className="bg-white shadow rounded-lg overflow-hidden">
-          <div className="px-4 py-5 sm:px-6 border-b border-gray-200">
-            <h3 className="text-lg leading-6 font-medium text-gray-900">출금 요청 목록</h3>
-            <p className="mt-1 max-w-2xl text-sm text-gray-500">총 {totalItems}개의 요청이 있습니다</p>
+      <div className="card shadow-sm bg-card">
+        <div className="card-header p-6 pb-5 flex justify-between items-center">
+          <div>
+            <h3 className="card-title text-lg font-semibold">출금 요청 목록</h3>
+            <p className="mt-1 text-sm text-gray-500">총 {totalItems}개의 요청이 있습니다</p>
           </div>
-          
-          <div className="px-4 py-5 sm:p-6">
-            {/* 검색 영역 */}
-            <WithdrawRequestSearchBar 
-              onSearch={handleSearch} 
-              initialParams={searchParams}
-            />
-            
-            {/* 리스트 영역 */}
-            <WithdrawRequestList 
-              requests={requests}
-              loading={loading}
-              totalItems={totalItems}
-              currentPage={currentPage}
-              itemsPerPage={itemsPerPage}
-              onPageChange={handlePageChange}
-              onRequestUpdated={handleRequestUpdated}
-            />
-          </div>
+        </div>
+
+        <div className="card-body p-6">
+          {/* 검색 영역 */}
+          <WithdrawRequestSearchBar
+            onSearch={handleSearch}
+            initialParams={searchParams}
+          />
+
+          {/* 리스트 영역 */}
+          <WithdrawRequestList
+            requests={requests}
+            loading={loading}
+            totalItems={totalItems}
+            currentPage={currentPage}
+            itemsPerPage={itemsPerPage}
+            onPageChange={handlePageChange}
+            onRequestUpdated={handleRequestUpdated}
+          />
         </div>
       </div>
     </CommonTemplate>

--- a/src/pages/admin/withdraw/WithdrawSettingPage.tsx
+++ b/src/pages/admin/withdraw/WithdrawSettingPage.tsx
@@ -9,7 +9,7 @@ import { DefaultTooltip } from '@/components/tooltip';
 
 const WithdrawSettingPage: React.FC = () => {
     // 출금 설정 페이지 제목
-    const title = '출금 설정 관리';
+    const title = '관리자 출금 설정';
 
     // 기본 설정 상태값
     const [globalSettings, setGlobalSettings] = useState({

--- a/src/pages/admin/withdraw/components/WithdrawGlobalForm.tsx
+++ b/src/pages/admin/withdraw/components/WithdrawGlobalForm.tsx
@@ -107,7 +107,7 @@ const WithdrawGlobalForm: React.FC<WithdrawGlobalFormProps> = ({ settings, onSav
               type="text"
               name="min_request_amount"
               placeholder="예: 10,000"
-              className="pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary h-10"
+              className="input pl-8 block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary h-10"
               value={formattedValues.min_request_amount}
               onChange={handleChange}
             />
@@ -135,7 +135,7 @@ const WithdrawGlobalForm: React.FC<WithdrawGlobalFormProps> = ({ settings, onSav
               type="number"
               name="min_request_percentage"
               placeholder="예: 5"
-              className="block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-12 h-10"
+              className="input block w-full p-2 border border-border dark:border-gray-600 bg-background text-foreground rounded-md focus:ring-primary focus:border-primary pr-12 h-10"
               value={formattedValues.min_request_percentage}
               onChange={handleChange}
               min="0"
@@ -152,7 +152,7 @@ const WithdrawGlobalForm: React.FC<WithdrawGlobalFormProps> = ({ settings, onSav
         <div className="flex items-end">
           <button
             type="submit"
-            className="inline-flex justify-center items-center px-6 py-2.5 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-colors h-10"
+            className="btn btn-primary inline-flex justify-center items-center px-6 py-2.5 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-colors h-10"
             disabled={savingGlobal}
           >
             {savingGlobal ? (

--- a/src/pages/admin/withdraw/components/WithdrawRequestList.tsx
+++ b/src/pages/admin/withdraw/components/WithdrawRequestList.tsx
@@ -229,7 +229,7 @@ export const WithdrawRequestList: React.FC<WithdrawRequestListProps> = ({
   const totalPages = Math.ceil(totalItems / itemsPerPage)
 
   return (
-    <div className="w-full">
+    <div className="w-full card">
       {loading ? (
         <div className="flex justify-center items-center py-10">
           <div className="animate-spin rounded-full h-10 w-10 border-4 border-blue-500 border-t-transparent"></div>
@@ -296,7 +296,7 @@ export const WithdrawRequestList: React.FC<WithdrawRequestListProps> = ({
           </div>
 
           {/* 테이블 뷰 (md 이상 화면에서만 표시) */}
-          <div className="hidden md:block overflow-x-auto rounded-lg shadow-sm border border-gray-200">
+          <div className="hidden md:block overflow-x-auto rounded-lg shadow-sm border border-gray-200 card">
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>

--- a/src/pages/admin/withdraw/components/WithdrawRequestSearchBar.tsx
+++ b/src/pages/admin/withdraw/components/WithdrawRequestSearchBar.tsx
@@ -62,15 +62,15 @@ const WithdrawRequestSearchBar: React.FC<WithdrawRequestSearchBarProps> = ({ onS
   };
 
   return (
-    <div className="w-full mb-6">
-      <div className="bg-gray-50 rounded-lg p-4">
+    <div className="w-full mb-4">
+      <div className="bg-gray-50 rounded-lg p-3 card">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-4">
           {/* 검색 유형 선택 */}
           <div className="lg:col-span-2">
             <select
               value={searchType}
               onChange={(e) => setSearchType(e.target.value)}
-              className="w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="select w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {searchTypes.map((type) => (
                 <option key={type.value} value={type.value}>
@@ -87,7 +87,7 @@ const WithdrawRequestSearchBar: React.FC<WithdrawRequestSearchBarProps> = ({ onS
               value={searchKeyword}
               onChange={(e) => setSearchKeyword(e.target.value)}
               placeholder="검색어를 입력하세요"
-              className="w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="input w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
@@ -96,7 +96,7 @@ const WithdrawRequestSearchBar: React.FC<WithdrawRequestSearchBarProps> = ({ onS
             <select
               value={status}
               onChange={(e) => setStatus(e.target.value)}
-              className="w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="select w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {statusTypes.map((type) => (
                 <option key={type.value} value={type.value}>
@@ -112,7 +112,7 @@ const WithdrawRequestSearchBar: React.FC<WithdrawRequestSearchBarProps> = ({ onS
               type="date"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              className="w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="input w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
@@ -122,7 +122,7 @@ const WithdrawRequestSearchBar: React.FC<WithdrawRequestSearchBarProps> = ({ onS
               type="date"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
-              className="w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="input w-full h-10 px-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
@@ -130,7 +130,7 @@ const WithdrawRequestSearchBar: React.FC<WithdrawRequestSearchBarProps> = ({ onS
           <div className="lg:col-span-2">
             <button
               onClick={handleSearch}
-              className="w-full h-10 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+              className="btn btn-primary w-full h-10 flex items-center justify-center"
             >
               검색
             </button>

--- a/src/pages/myinfo/ProfilePage.tsx
+++ b/src/pages/myinfo/ProfilePage.tsx
@@ -4,7 +4,7 @@ import { KeenIcon } from '@/components';
 import { supabase } from '@/supabase';
 import { CommonTemplate } from '@/components/pageTemplate';
 import { BusinessUpgradeModal } from '@/components/business';
-import { USER_ROLES, getRoleDisplayName, getRoleBadgeColor } from '@/config/roles.config';
+import { USER_ROLES, getRoleDisplayName, getRoleBadgeColor, getRoleThemeColors } from '@/config/roles.config';
 
 const ProfilePage = () => {
   const { currentUser, setCurrentUser } = useAuthContext();
@@ -76,8 +76,11 @@ const ProfilePage = () => {
     }
   }, [currentUser]);
 
-  const roleClass = currentUser?.role ? `badge-${getRoleBadgeColor(currentUser.role)}` : '';
+  const roleClass = currentUser?.role ? `bg-${getRoleBadgeColor(currentUser.role)}/10 text-${getRoleBadgeColor(currentUser.role)}` : '';
   const roleText = currentUser?.role ? getRoleDisplayName(currentUser.role) : '';
+
+  // 역할별 테마 색상 가져오기
+  const roleThemeColors = currentUser?.role ? getRoleThemeColors(currentUser.role) : null;
 
   const statusClass = currentUser?.status === 'active' ? 'badge-success' :
     currentUser?.status === 'inactive' ? 'badge-secondary' :
@@ -462,7 +465,11 @@ const ProfilePage = () => {
               <h3 className="text-lg font-medium">
                 {currentUser?.full_name || '사용자'}
               </h3>
-              <span className={`badge ${roleClass} px-2 py-1 rounded text-xs`}>
+              <span className={`badge ${roleClass} px-2 py-1 rounded text-xs`}
+                style={roleThemeColors ? {
+                  backgroundColor: `${roleThemeColors.baseHex}15`, /* 10% 투명도 */
+                  color: roleThemeColors.baseHex
+                } : undefined}>
                 {roleText || '사용자'}
               </span>
             </div>

--- a/src/pages/myinfo/ProfilePage.tsx
+++ b/src/pages/myinfo/ProfilePage.tsx
@@ -4,7 +4,7 @@ import { KeenIcon } from '@/components';
 import { supabase } from '@/supabase';
 import { CommonTemplate } from '@/components/pageTemplate';
 import { BusinessUpgradeModal } from '@/components/business';
-import { USER_ROLES, getRoleDisplayName, getRoleBadgeColor, getRoleThemeColors } from '@/config/roles.config';
+import { USER_ROLES, USER_ROLE_THEME_COLORS, getRoleDisplayName, getRoleBadgeColor, getRoleThemeColors, RoleThemeColors } from '@/config/roles.config';
 
 const ProfilePage = () => {
   const { currentUser, setCurrentUser } = useAuthContext();
@@ -80,7 +80,7 @@ const ProfilePage = () => {
   const roleText = currentUser?.role ? getRoleDisplayName(currentUser.role) : '';
 
   // 역할별 테마 색상 가져오기
-  const roleThemeColors = currentUser?.role ? getRoleThemeColors(currentUser.role) : null;
+  const roleThemeColors = currentUser?.role ? USER_ROLE_THEME_COLORS[currentUser.role] || null : null;
 
   const statusClass = currentUser?.status === 'active' ? 'badge-success' :
     currentUser?.status === 'inactive' ? 'badge-secondary' :


### PR DESCRIPTION
1. 역할별 색상 정의 적용
 - 내 정보 관리 페이지(/myinfo/profile) 역할 배지
 - 사용자 관리 페이지(/admin/users) 사용자 목록의 권한
 - 알림 관리 페이지(/admin/site/notification) 의 알림 목록의 회원 유형, 회원별 알림 전송 모달에 회원 목록에 회원 유형
2. 등업 신청 관리 페이지(/admin/levelup-requests) 등업 신청 목록에서 사업자등록증 미리보기 이미지 페이지영역에서 전체영역으로 수정
3. 기타 페이지 디자인 수정
 - 운영자 출금 승인 페이지(/admin/withdraw_approve) 의 출금 요청 목록 width 재정의
 - 각 컴포넌트 클래스 정리(select, input 클래스 추가) 및 마진 정리, 불필요 클래스 제거, card 클래스 추가 외
  > 운영자 출금 승인 페이지(/admin/withdraw_approve)
  > 관리자 출금 설정 페이지(/admin/withdraw_setting)
  > 캐시 설정 페이지(/admin/cash_setting)