### PR TITLE
[수정사항 반영]

### DIFF
--- a/src/auth/pages/jwt/Login.tsx
+++ b/src/auth/pages/jwt/Login.tsx
@@ -6,9 +6,8 @@ import { useFormik } from 'formik';
 import { KeenIcon } from '@/components';
 import { toAbsoluteUrl } from '@/utils';
 import { useAuthContext } from '@/auth';
-import { useLayout } from '@/providers';
+import { useLayout, useToast } from '@/providers';
 import { Alert } from '@/components';
-import { toast } from 'sonner';
 
 // 유효성 검증 스키마 - 한글 메시지로 변경
 const loginSchema = Yup.object().shape({
@@ -81,6 +80,7 @@ const Login = () => {
   const [showErrorHelp, setShowErrorHelp] = useState(false);
   const { login, resetPassword } = useAuthContext();
   const { currentLayout } = useLayout();
+  const toast = useToast();
   const navigate = useNavigate();
   const location = useLocation();
   const from = location.state?.from?.pathname || '/';
@@ -245,8 +245,8 @@ const Login = () => {
                         key={role}
                         type="button"
                         className={`px-2 py-1 rounded text-xs ${selectedRole === role
-                            ? 'bg-blue-600 text-white font-semibold'
-                            : 'bg-blue-100 text-blue-800 hover:bg-blue-200'
+                          ? 'bg-blue-600 text-white font-semibold'
+                          : 'bg-blue-100 text-blue-800 hover:bg-blue-200'
                           }`}
                         onClick={() => setSelectedRole(role as keyof typeof testCredentials)}
                       >
@@ -258,6 +258,18 @@ const Login = () => {
               </div>
             )}
           </div>
+
+          {/* 회원가입 완료 메시지 표시 */}
+          {location.state?.registeredEmail && (
+            <Alert variant="success" className="mb-4">
+              <div className="flex items-start gap-2">
+                <div>
+                  <div className="font-semibold mb-1">회원가입이 완료되었습니다!</div>
+                  <div className="text-sm">가입하신 이메일과 비밀번호로 로그인해주세요.</div>
+                </div>
+              </div>
+            </Alert>
+          )}
 
           {formik.status && <Alert variant="danger">{formik.status}</Alert>}
 

--- a/src/auth/pages/jwt/Signup.tsx
+++ b/src/auth/pages/jwt/Signup.tsx
@@ -9,7 +9,7 @@ import debounce from 'lodash/debounce';
 import { useAuthContext } from '../../useAuthContext';
 import { toAbsoluteUrl } from '@/utils';
 import { Alert, KeenIcon } from '@/components';
-import { useLayout } from '@/providers';
+import { useLayout, useToast } from '@/providers';
 
 const initialValues = {
   email: '',
@@ -44,6 +44,7 @@ const Signup = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const { currentLayout } = useLayout();
+  const toast = useToast();
   const [isCheckingEmail, setIsCheckingEmail] = useState(false);
   const [isEmailTaken, setIsEmailTaken] = useState(false);
   const [isEmailValid, setIsEmailValid] = useState(false);
@@ -73,12 +74,19 @@ const Signup = () => {
         // 추출한 이메일 앞부분을 full_name으로 사용
         await register(values.email, emailUsername, values.password, values.changepassword);
         
+        // 성공 메시지 표시
+        toast.success('회원가입이 완료되었습니다! 로그인 페이지로 이동합니다...');
+        
         // 회원가입 완료 후 로그인 페이지로 이동하면서 이메일 정보 전달
         const loginPath = currentLayout?.name === 'auth-branded' ? '/auth/login' : '/auth/classic/login';
-        navigate(loginPath, { 
-          replace: true,
-          state: { registeredEmail: values.email }
-        });
+        
+        // 약간의 딜레이 후 페이지 이동
+        setTimeout(() => {
+          navigate(loginPath, { 
+            replace: true,
+            state: { registeredEmail: values.email }
+          });
+        }, 1000);
       } catch (error) {
         setStatus('회원가입에 실패했습니다. 입력 정보를 확인해주세요.');
         setSubmitting(false);

--- a/src/auth/providers/AuthProvider.tsx
+++ b/src/auth/providers/AuthProvider.tsx
@@ -273,7 +273,7 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
                             email: user.email || '',
                             full_name: user.user_metadata?.full_name || '',
                             phone_number: '',
-                            role: metadataRole || USER_ROLES.BEGINNER,
+                            role: metadataRole || USER_ROLES.ADVERTISER,
                             status: 'active',
                             raw_user_meta_data: user.user_metadata
                         };
@@ -288,7 +288,7 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
                         email: user.email || '',
                         full_name: user.user_metadata?.full_name || '',
                         phone_number: '',
-                        role: metadataRole || USER_ROLES.BEGINNER,
+                        role: metadataRole || USER_ROLES.ADVERTISER,
                         status: 'active',
                         raw_user_meta_data: user.user_metadata
                     };

--- a/src/components/campaign-modals/CampaignForm.tsx
+++ b/src/components/campaign-modals/CampaignForm.tsx
@@ -434,7 +434,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
           <tbody className="divide-y divide-border">
             {/* 서비스타입 선택 */}
             <tr>
-              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 서비스타입 <span className="text-red-500">*</span>
               </th>
               <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -475,7 +475,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
 
             {formData.slotType !== 'guarantee' && (
               <tr>
-                <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+                <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                   건당 단가 <span className="text-red-500">*</span>
                 </th>
                 <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -496,7 +496,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
             )}
 
             <tr>
-              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 배너 이미지
               </th>
               <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -560,7 +560,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
             {/* 최소수량 - 일반 서비스일 때만 표시 */}
             {formData.slotType !== 'guarantee' && (
               <tr>
-                <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+                <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                   최소수량 <span className="text-red-500">*</span>
                 </th>
                 <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -588,7 +588,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
               <>
                 {/* 보장 횟수/일수 */}
                 <tr>
-                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                     보장 일수(횟수) <span className="text-red-500">*</span>
                   </th>
                   <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -627,7 +627,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
 
                 {/* 보장 순위 */}
                 <tr>
-                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                     보장 순위 <span className="text-red-500">*</span>
                   </th>
                   <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -657,7 +657,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
 
                 {/* 최소 보장 가격 */}
                 <tr>
-                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                     최소 가격 <span className="text-red-500">*</span>
                   </th>
                   <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -679,7 +679,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
 
                 {/* 최대 보장 가격 */}
                 <tr>
-                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                     최대 가격 <span className="text-red-500">*</span>
                   </th>
                   <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -702,7 +702,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
             )}
 
             <tr>
-              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 캠페인 소개 <span className="text-red-500">*</span>
               </th>
               <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -718,7 +718,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
             </tr>
 
             <tr>
-              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 캠페인 상세설명 <span className="text-red-500">*</span>
               </th>
               <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -734,7 +734,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
             </tr>
 
             <tr>
-              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px] align-top">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px] align-top">
                 사용자 입력 필드
               </th>
               <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
@@ -978,7 +978,7 @@ const CampaignForm: React.FC<CampaignFormProps> = ({
             {serviceType && serviceTypeInfoMap[serviceType] &&
               Object.entries(serviceTypeInfoMap[serviceType].additionalFields).map(([fieldKey, fieldInfo]) => (
                 <tr key={fieldKey}>
-                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide min-w-[96px] max-w-[96px] sm:min-w-[128px] sm:max-w-[128px] md:min-w-[160px] md:max-w-[160px]">
+                  <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                     {fieldInfo.label}
                     {fieldInfo.required && <span className="text-red-500 ml-1">*</span>}
                   </th>

--- a/src/components/campaign-modals/CampaignSlotWithKeywordModal.tsx
+++ b/src/components/campaign-modals/CampaignSlotWithKeywordModal.tsx
@@ -1881,7 +1881,7 @@ const CampaignSlotWithKeywordModal: React.FC<CampaignSlotWithKeywordModalProps> 
         .from('notifications')
         .insert({
           user_id: userId,
-          type: 'slot_created', // 슬롯 생성 타입
+          type: 'service', // 서비스 타입
           title: title,
           message: message,
           link: link,
@@ -2016,6 +2016,16 @@ const CampaignSlotWithKeywordModal: React.FC<CampaignSlotWithKeywordModalProps> 
           `${selectedCampaign?.campaign_name || ''} - ${result.slots.length}개의 키워드 구매 신청이 완료되었습니다.`,
           '/myinfo/services'
         );
+        
+        // 총판에게 알림 전송 (mat_id가 있는 경우)
+        if (selectedCampaign?.mat_id && selectedCampaign.mat_id !== currentUser?.id) {
+          await createNotification(
+            selectedCampaign.mat_id,
+            '새로운 슬롯 구매 신청',
+            `${currentUser?.email || '사용자'}님이 ${selectedCampaign?.campaign_name || ''} - ${result.slots.length}개의 키워드를 구매 신청했습니다.`,
+            '/manage/slots/approve'
+          );
+        }
       }
 
       // 상위 컴포넌트에 데이터 전달 (기존 동작 유지)
@@ -2267,6 +2277,16 @@ const CampaignSlotWithKeywordModal: React.FC<CampaignSlotWithKeywordModalProps> 
         `${selectedCampaign.campaign_name} - 수동 입력 모드로 구매 신청이 완료되었습니다.`,
         '/myinfo/services'
       );
+      
+      // 총판에게 알림 전송 (mat_id가 있는 경우)
+      if (selectedCampaign?.mat_id && selectedCampaign.mat_id !== currentUser?.id) {
+        await createNotification(
+          selectedCampaign.mat_id,
+          '새로운 슬롯 구매 신청',
+          `${currentUser?.email || '사용자'}님이 ${selectedCampaign?.campaign_name || ''} - 수동 입력 모드로 구매 신청했습니다.`,
+          '/manage/slots/approve'
+        );
+      }
 
       // 성공 후 초기화 - 캠페인 기본값 유지
       const minQuantity = selectedCampaign.min_quantity ? Number(selectedCampaign.min_quantity) : 1;

--- a/src/components/campaign-modals/campaign-slot-components/DirectInputKeywordForm.tsx
+++ b/src/components/campaign-modals/campaign-slot-components/DirectInputKeywordForm.tsx
@@ -131,8 +131,8 @@ export const DirectInputKeywordForm: React.FC<DirectInputKeywordFormProps> = ({
   return (
     <div className="w-full">
       <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg p-4 space-y-4">
-        {/* DB 설정 기반 키워드 필드 */}
-        {keywordFields.map((field) => (
+        {/* DB 설정 기반 키워드 필드 - 임시 주석 처리 */}
+        {/* {keywordFields.map((field) => (
           <div key={field.fieldName}>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               {field.label || field.fieldName} 
@@ -153,7 +153,22 @@ export const DirectInputKeywordForm: React.FC<DirectInputKeywordFormProps> = ({
               <p className="text-xs text-gray-500 mt-1">{field.tooltip}</p>
             )}
           </div>
-        ))}
+        ))} */}
+
+        {/* 메인 키워드 필드 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            메인 키워드 <span className="text-red-500">*</span>
+          </label>
+          <Input
+            type="text"
+            value={slotData.mainKeyword || slotData.input_data?.main_keyword || ''}
+            onChange={(e) => handleFieldChange('main_keyword', e.target.value)}
+            placeholder="메인 키워드를 입력하세요"
+            className="w-full"
+          />
+          <p className="text-xs text-gray-500 mt-1">작업의 핵심이 되는 메인 키워드를 입력해주세요.</p>
+        </div>
 
         {/* 기본 필드 (최소 구매수, 작업일) */}
         <div className="grid grid-cols-2 gap-4">

--- a/src/components/campaign-modals/types.ts
+++ b/src/components/campaign-modals/types.ts
@@ -37,6 +37,25 @@ export const SERVICE_TYPE_LABELS: Record<string, string> = {
   [CampaignServiceType.LIVE_BROADCASTING]: '라이브방송'
 };
 
+// 메뉴 순서대로 정렬된 서비스 타입 배열
+export const SERVICE_TYPE_ORDER = [
+  CampaignServiceType.NAVER_TRAFFIC,
+  CampaignServiceType.NAVER_SHOPPING_RANK,
+  CampaignServiceType.NAVER_SHOPPING_TRAFFIC,
+  CampaignServiceType.NAVER_SHOPPING_FAKESALE,
+  CampaignServiceType.NAVER_PLACE_RANK,
+  CampaignServiceType.NAVER_PLACE_TRAFFIC,
+  CampaignServiceType.NAVER_PLACE_SAVE,
+  CampaignServiceType.NAVER_PLACE_SHARE,
+  CampaignServiceType.NAVER_BLOG_POST,
+  CampaignServiceType.NAVER_AUTO,
+  CampaignServiceType.COUPANG_TRAFFIC,
+  CampaignServiceType.COUPANG_FAKESALE,
+  CampaignServiceType.INSTAGRAM,
+  CampaignServiceType.PHOTO_VIDEO_PRODUCTION,
+  CampaignServiceType.LIVE_BROADCASTING
+];
+
 // DB의 snake_case를 enum의 PascalCase로 변환하는 함수
 export const convertDbServiceTypeToEnum = (dbServiceType: string): string => {
   const typeMap: { [key: string]: string } = {

--- a/src/components/cash/ChargeModal.tsx
+++ b/src/components/cash/ChargeModal.tsx
@@ -177,7 +177,7 @@ const ChargeModal: React.FC<ChargeModalProps> = ({ open, onClose }) => {
     setIsLoadingHistory(true);
 
     try {
-      const result = await CashService.getChargeRequestHistory(currentUser.id || '', 5);
+      const result = await CashService.getChargeRequestHistory(currentUser.id || '', 3);
 
       if (result.success) {
         const requests = result.data || [];
@@ -568,18 +568,18 @@ const ChargeModal: React.FC<ChargeModalProps> = ({ open, onClose }) => {
             {/* 최근 충전 요청 내역 */}
             <div className="mb-4">
               <div className="mb-3 flex justify-between items-center">
-                <p className="text-sm font-medium">최근 충전 요청 내역</p>
+                <p className="text-sm font-medium">최근 충전 내역 (최근 3건)</p>
                 <button
                   type="button"
-                  className="text-xs text-primary hover:text-primary-dark hover:underline flex items-center bg-transparent border-0 p-0 cursor-pointer"
+                  className="text-xs text-primary hover:text-primary-dark hover:underline flex items-center gap-1 bg-transparent border-0 p-0 cursor-pointer"
                   onClick={() => {
                     // 모달 닫고 해당 페이지로 이동
                     handleModalClose();
                     navigate('/cash/history');
                   }}
                 >
-                  <span>충전내역 확인</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5 ml-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <span>상세보기</span>
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>
                 </button>
@@ -591,7 +591,7 @@ const ChargeModal: React.FC<ChargeModalProps> = ({ open, onClose }) => {
                 </div>
               ) : recentRequests.length > 0 ? (
                 <div className="border border-border rounded-md overflow-hidden">
-                  <div className="h-[200px] overflow-auto">
+                  <div className="max-h-[200px] overflow-auto">
                     <table className="w-full text-sm table-fixed">
                       <colgroup>
                         <col className="w-[25%]" />

--- a/src/components/refund/RefundSettingsForm.tsx
+++ b/src/components/refund/RefundSettingsForm.tsx
@@ -82,20 +82,20 @@ export const RefundSettingsForm: React.FC<RefundSettingsFormProps> = ({
       <tbody className="divide-y divide-border">
         {/* 환불 허용 */}
         <tr>
-          <th className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 text-left text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider w-1/4">
+          <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
             환불 허용
           </th>
-          <td className="px-6 py-4 bg-white dark:bg-gray-800/20">
-            <div className="flex items-center justify-between">
-              <p className="text-sm text-muted-foreground">
-                이 캠페인의 환불 가능 여부를 설정합니다
-              </p>
+          <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
+            <div className="flex items-center gap-3">
               <Switch
                 id="refund-enabled"
                 checked={settings.enabled}
                 onCheckedChange={handleToggleRefund}
                 disabled={disabled}
               />
+              <p className="text-xs sm:text-sm text-muted-foreground">
+                이 캠페인의 환불 가능 여부를 설정합니다
+              </p>
             </div>
           </td>
         </tr>
@@ -104,16 +104,16 @@ export const RefundSettingsForm: React.FC<RefundSettingsFormProps> = ({
           <>
             {/* 환불 시점 */}
             <tr>
-              <th className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 text-left text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider w-1/4">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 환불 시점
               </th>
-              <td className="px-6 py-4 bg-white dark:bg-gray-800/20">
+              <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
                 <div className="space-y-3">
                   {isModal ? (
                     <select
                       value={settings.type}
                       onChange={(e) => handleTypeChange(e.target.value as RefundSettings['type'])}
-                      className="w-full h-10 px-3 py-2 border border-gray-200 bg-white text-foreground rounded-md"
+                      className="select select-bordered select-sm w-full max-w-xs"
                       disabled={disabled}
                     >
                       <option value="immediate">즉시 환불</option>
@@ -145,7 +145,7 @@ export const RefundSettingsForm: React.FC<RefundSettingsFormProps> = ({
                         max="30"
                         disabled={disabled}
                       />
-                      <span className="text-sm">일 후 환불</span>
+                      <span className="text-sm ml-2">일 후 환불</span>
                     </div>
                   )}
 
@@ -169,30 +169,30 @@ export const RefundSettingsForm: React.FC<RefundSettingsFormProps> = ({
 
             {/* 총판 승인 필요 */}
             <tr>
-              <th className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 text-left text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider w-1/4">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 총판 승인 필요
               </th>
-              <td className="px-6 py-4 bg-white dark:bg-gray-800/20">
-                <div className="flex items-center justify-between">
-                  <p className="text-sm text-muted-foreground">
-                    환불 시 총판의 승인이 필요한지 설정합니다
-                  </p>
+              <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
+                <div className="flex items-center gap-3">
                   <Switch
                     id="requires-approval"
                     checked={settings.requires_approval}
                     onCheckedChange={handleRequiresApprovalChange}
                     disabled={disabled}
                   />
+                  <p className="text-xs sm:text-sm text-muted-foreground">
+                    환불 시 총판의 승인이 필요한지 설정합니다
+                  </p>
                 </div>
               </td>
             </tr>
 
             {/* 최소 사용 일수 */}
             <tr>
-              <th className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 text-left text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider w-1/4">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 최소 사용 일수
               </th>
-              <td className="px-6 py-4 bg-white dark:bg-gray-800/20">
+              <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
                 <div className="flex items-center gap-2">
                   <Input
                     type="number"
@@ -203,7 +203,7 @@ export const RefundSettingsForm: React.FC<RefundSettingsFormProps> = ({
                     max="365"
                     disabled={disabled}
                   />
-                  <span className="text-sm">일</span>
+                  <span className="text-sm ml-2">일</span>
                   <span className="text-xs text-muted-foreground ml-2">
                     (이 기간 이상 사용해야 환불 가능)
                   </span>
@@ -213,10 +213,10 @@ export const RefundSettingsForm: React.FC<RefundSettingsFormProps> = ({
 
             {/* 최대 환불 가능 일수 */}
             <tr>
-              <th className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 text-left text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider w-1/4">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 최대 환불 가능 일수
               </th>
-              <td className="px-6 py-4 bg-white dark:bg-gray-800/20">
+              <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
                 <div className="flex items-center gap-2">
                   <Input
                     type="number"
@@ -227,7 +227,7 @@ export const RefundSettingsForm: React.FC<RefundSettingsFormProps> = ({
                     max="365"
                     disabled={disabled}
                   />
-                  <span className="text-sm">일</span>
+                  <span className="text-sm ml-2">일</span>
                   <span className="text-xs text-muted-foreground ml-2">
                     (사용 시작 후 이 기간 내에만 환불 가능)
                   </span>
@@ -237,38 +237,38 @@ export const RefundSettingsForm: React.FC<RefundSettingsFormProps> = ({
 
             {/* 일할 계산 환불 */}
             <tr>
-              <th className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 text-left text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider w-1/4">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 일할 계산 환불
               </th>
-              <td className="px-6 py-4 bg-white dark:bg-gray-800/20">
-                <div className="flex items-center justify-between">
-                  <p className="text-sm text-muted-foreground">
-                    사용한 기간을 제외한 금액만 환불 (실제 환불 금액은 작업량과 상황에 따라 결정)
-                  </p>
+              <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
+                <div className="flex items-center gap-3">
                   <Switch
                     id="partial-refund"
                     checked={settings.refund_rules.partial_refund}
                     onCheckedChange={(checked) => handleRulesChange('partial_refund', checked)}
                     disabled={disabled}
                   />
+                  <p className="text-xs sm:text-sm text-muted-foreground">
+                    사용한 기간을 제외한 금액만 환불 (실제 환불 금액은 작업량과 상황에 따라 결정)
+                  </p>
                 </div>
               </td>
             </tr>
 
             {/* 환불 정책 요약 */}
             <tr>
-              <th className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 text-left text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider w-1/4">
+              <th className="px-3 py-1.5 sm:px-4 sm:py-2 bg-muted/50 text-left text-xs sm:text-sm font-semibold text-foreground uppercase tracking-wide w-[96px] sm:w-[128px] md:w-[200px]">
                 환불 정책 요약
               </th>
-              <td className="px-6 py-4 bg-white dark:bg-gray-800/20">
-                <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4">
-                  <ul className="space-y-1 text-sm text-gray-700 dark:text-gray-300">
+              <td className="px-3 py-1.5 sm:px-4 sm:py-2 bg-background">
+                <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3">
+                  <ul className="space-y-1 text-xs sm:text-sm text-gray-700 dark:text-gray-300">
                     <li className="flex items-start gap-2">
                       <KeenIcon icon="check" className="size-4 text-blue-500 mt-0.5 flex-shrink-0" />
                       <span>
-                        환불 시점: {settings.type === 'immediate' ? '즉시' : 
-                          settings.type === 'delayed' ? `${settings.delay_days}일 후` : 
-                          `마감시간(${settings.cutoff_time}) 기준`}
+                        환불 시점: {settings.type === 'immediate' ? '즉시' :
+                          settings.type === 'delayed' ? `${settings.delay_days}일 후` :
+                            `마감시간(${settings.cutoff_time}) 기준`}
                       </span>
                     </li>
                     <li className="flex items-start gap-2">

--- a/src/components/service-effect-modal/ServiceEffectViewerModal.tsx
+++ b/src/components/service-effect-modal/ServiceEffectViewerModal.tsx
@@ -34,6 +34,9 @@ export const ServiceEffectViewerModal: React.FC<ServiceEffectViewerModalProps> =
   const { userRole, currentUser } = useAuthContext();
   const { showToast } = useCustomToast();
   
+  // 다크모드 감지
+  const isDarkMode = document.documentElement.classList.contains('dark');
+  
   // DialogProvider 내부에서만 사용하도록 try-catch로 안전하게 처리
   let dialogMethods: any = null;
   try {
@@ -193,9 +196,9 @@ export const ServiceEffectViewerModal: React.FC<ServiceEffectViewerModalProps> =
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="max-w-6xl w-[90vw] h-[85vh] overflow-hidden flex flex-col">
+      <DialogContent className="max-w-6xl w-[90vw] h-[85vh] overflow-hidden flex flex-col bg-white dark:bg-gray-900">
         <DialogHeader>
-          <DialogTitle>{serviceName} 효과 및 사용법</DialogTitle>
+          <DialogTitle className="text-gray-900 dark:text-gray-100">{serviceName} 효과 및 사용법</DialogTitle>
           <DialogDescription className="sr-only">
             {serviceName} 서비스의 효과와 사용법을 확인하실 수 있습니다.
           </DialogDescription>
@@ -216,7 +219,7 @@ export const ServiceEffectViewerModal: React.FC<ServiceEffectViewerModalProps> =
         <DialogBody className="px-6 py-4 flex-1 min-h-0">
           {isLoading ? (
             <div className="flex items-center justify-center h-full">
-              <div className="text-gray-500">로딩 중...</div>
+              <div className="text-gray-500 dark:text-gray-400">로딩 중...</div>
             </div>
           ) : isEditMode ? (
             <div className="h-full">
@@ -224,7 +227,7 @@ export const ServiceEffectViewerModal: React.FC<ServiceEffectViewerModalProps> =
                 content={content}
                 onChange={setContent}
                 height="100%"
-                theme="light"
+                theme={isDarkMode ? "dark" : "light"}
                 placeholder="효과 및 사용법을 입력하세요..."
               />
             </div>
@@ -233,7 +236,7 @@ export const ServiceEffectViewerModal: React.FC<ServiceEffectViewerModalProps> =
               <ToastUIViewer
                 content={content}
                 height="auto"
-                theme="light"
+                theme={isDarkMode ? "dark" : "light"}
               />
             </div>
           )}

--- a/src/pages/admin/slots/components/SearchForm.tsx
+++ b/src/pages/admin/slots/components/SearchForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Campaign } from './types';
 import { STATUS_OPTIONS } from './constants';
-import { SERVICE_TYPE_LABELS } from '@/components/campaign-modals/types';
+import { SERVICE_TYPE_LABELS, SERVICE_TYPE_ORDER } from '@/components/campaign-modals/types';
 import { USER_ROLES } from '@/config/roles.config';
 
 interface SearchFormProps {
@@ -53,8 +53,8 @@ const SearchForm: React.FC<SearchFormProps> = ({
   const isDistributor = userRole === USER_ROLES.DISTRIBUTOR;
   const hasAvailableServices = availableServiceTypes && availableServiceTypes.length > 0;
   
-  // 실제로 표시할 서비스 타입들
-  const serviceTypesToDisplay = availableServiceTypes || Object.keys(SERVICE_TYPE_LABELS);
+  // 실제로 표시할 서비스 타입들 (메뉴 순서대로 정렬)
+  const serviceTypesToDisplay = availableServiceTypes || SERVICE_TYPE_ORDER;
   return (
     <div className="card shadow-sm mb-5">
       <div className="card-header px-6 py-4">
@@ -78,6 +78,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
                   onChange={onServiceTypeChange}
                   disabled={loading || serviceTypesToDisplay.length === 0}
                 >
+                  <option value="">전체 서비스</option>
                   {serviceTypesToDisplay.map((serviceType) => (
                     <option key={serviceType} value={serviceType}>
                       {SERVICE_TYPE_LABELS[serviceType] || serviceType}
@@ -227,6 +228,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
                   onChange={onServiceTypeChange}
                   disabled={loading || serviceTypesToDisplay.length === 0}
                 >
+                  <option value="">전체 서비스</option>
                   {serviceTypesToDisplay.map((serviceType) => (
                     <option key={serviceType} value={serviceType}>
                       {SERVICE_TYPE_LABELS[serviceType] || serviceType}

--- a/src/pages/cash/HistoryPage.tsx
+++ b/src/pages/cash/HistoryPage.tsx
@@ -1,18 +1,18 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Container } from '@/components';
+import { CommonTemplate } from '@/components/pageTemplate';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { 
+import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { 
-  Wallet, 
-  TrendingUp, 
-  TrendingDown, 
+import {
+  Wallet,
+  TrendingUp,
+  TrendingDown,
   RefreshCw,
   CircleDollarSign,
   ArrowUpRight,
@@ -120,7 +120,7 @@ const HistoryPage = () => {
 
   const loadData = async () => {
     if (!currentUser?.id) return;
-    
+
     setLoading(true);
     try {
       // 잔액 조회
@@ -161,10 +161,10 @@ const HistoryPage = () => {
   // 자동 완료 환불의 관련 슬롯 정보 로드
   const loadAutoRefundSlots = async (transaction: CashTransaction) => {
     console.log('loadAutoRefundSlots 호출됨:', transaction);
-    
-    if (!currentUser?.id || 
-        transaction.transaction_type !== 'refund' || 
-        !transaction.description?.includes('슬롯 자동 완료 환불')) {
+
+    if (!currentUser?.id ||
+      transaction.transaction_type !== 'refund' ||
+      !transaction.description?.includes('슬롯 자동 완료 환불')) {
       console.log('자동 환불이 아님, 조건 체크:', {
         hasUserId: !!currentUser?.id,
         isRefund: transaction.transaction_type === 'refund',
@@ -187,9 +187,9 @@ const HistoryPage = () => {
         transaction.transaction_at,
         Math.abs(transaction.amount)
       );
-      
+
       console.log('자동 환불 슬롯 조회 결과:', result);
-      
+
       if (result.success && result.data) {
         console.log('자동 환불 슬롯 설정:', result.data);
         setAutoRefundSlots(result.data);
@@ -264,7 +264,7 @@ const HistoryPage = () => {
     const isIncome = ['charge', 'free', 'referral_bonus', 'refund'].includes(type);
     const sign = isIncome ? '+' : '-';
     const className = isIncome ? 'text-green-600' : 'text-red-600';
-    
+
     return (
       <span className={`font-medium ${className}`}>
         {sign}{Math.abs(amount).toLocaleString()}원
@@ -275,12 +275,24 @@ const HistoryPage = () => {
   const filteredTransactions = getFilteredTransactions();
 
   return (
-    <Container>
+    <CommonTemplate
+      title="캐시 충전/사용내역"
+      description="캐시 잔액 및 거래 내역을 확인하세요"
+      showPageMenu={false}
+      childrenClassName=""
+      toolbarActions={
+        <Button
+          variant="outline"
+          size="sm"
+          className="bg-primary-600 text-white hover:bg-primary-700"
+          onClick={loadData}
+        >
+          <RefreshCw className="md:me-2 flex-none" />
+          새로고침
+        </Button>
+      }
+    >
       <div className="mx-auto max-w-7xl py-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold">캐시 충전/사용내역</h1>
-          <p className="text-gray-600 mt-1">캐시 잔액 및 거래 내역을 확인하세요</p>
-        </div>
 
         {/* 잔액 카드 */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 mb-6">
@@ -361,13 +373,7 @@ const HistoryPage = () => {
         {/* 거래 내역 */}
         <Card>
           <CardHeader>
-            <div className="flex justify-between items-center">
-              <CardTitle>거래 내역</CardTitle>
-              <Button variant="outline" size="sm" onClick={loadData}>
-                <RefreshCw className="h-4 w-4 mr-2" />
-                새로고침
-              </Button>
-            </div>
+            <CardTitle>거래 내역</CardTitle>
           </CardHeader>
           <CardContent>
             {/* 필터 탭 */}
@@ -375,41 +381,37 @@ const HistoryPage = () => {
               <div className="flex space-x-1 bg-gray-100 p-1 rounded-lg">
                 <button
                   onClick={() => setActiveTab('all')}
-                  className={`flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-medium transition-colors ${
-                    activeTab === 'all'
-                      ? 'bg-white text-gray-900 shadow-sm'
-                      : 'text-gray-600 hover:text-gray-900'
-                  }`}
+                  className={`flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-medium transition-colors ${activeTab === 'all'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                    }`}
                 >
                   전체
                 </button>
                 <button
                   onClick={() => setActiveTab('charge')}
-                  className={`flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-medium transition-colors ${
-                    activeTab === 'charge'
-                      ? 'bg-white text-gray-900 shadow-sm'
-                      : 'text-gray-600 hover:text-gray-900'
-                  }`}
+                  className={`flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-medium transition-colors ${activeTab === 'charge'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                    }`}
                 >
                   충전
                 </button>
                 <button
                   onClick={() => setActiveTab('use')}
-                  className={`flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-medium transition-colors ${
-                    activeTab === 'use'
-                      ? 'bg-white text-gray-900 shadow-sm'
-                      : 'text-gray-600 hover:text-gray-900'
-                  }`}
+                  className={`flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-medium transition-colors ${activeTab === 'use'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                    }`}
                 >
                   사용
                 </button>
                 <button
                   onClick={() => setActiveTab('refund')}
-                  className={`flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-medium transition-colors ${
-                    activeTab === 'refund'
-                      ? 'bg-white text-gray-900 shadow-sm'
-                      : 'text-gray-600 hover:text-gray-900'
-                  }`}
+                  className={`flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-medium transition-colors ${activeTab === 'refund'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                    }`}
                 >
                   환불
                 </button>
@@ -421,11 +423,11 @@ const HistoryPage = () => {
               <table className="w-full">
                 <thead>
                   <tr className="border-b">
-                    <th className="text-left py-3 px-2 text-sm font-medium text-gray-900 w-36">날짜</th>
-                    <th className="text-left py-3 px-2 text-sm font-medium text-gray-900 w-20">구분</th>
+                    <th className="text-center py-3 px-2 text-sm font-medium text-gray-900 w-36">날짜</th>
+                    <th className="text-center py-3 px-2 text-sm font-medium text-gray-900 w-20">구분</th>
                     <th className="text-left py-3 px-2 text-sm font-medium text-gray-900">내용</th>
-                    <th className="text-right py-3 px-2 text-sm font-medium text-gray-900 w-24">금액</th>
-                    <th className="text-left py-3 px-2 text-sm font-medium text-gray-900 w-16">타입</th>
+                    <th className="text-center py-3 px-2 text-sm font-medium text-gray-900 w-36">금액</th>
+                    <th className="text-center py-3 px-2 text-sm font-medium text-gray-900 w-16">타입</th>
                     <th className="text-center py-3 px-2 text-sm font-medium text-gray-900 w-16">상세</th>
                   </tr>
                 </thead>
@@ -445,11 +447,11 @@ const HistoryPage = () => {
                   ) : (
                     filteredTransactions.map((transaction) => (
                       <tr key={transaction.id} className="border-b hover:bg-gray-50">
-                        <td className="py-3 px-2 text-sm">
+                        <td className="py-3 px-2 text-sm text-center">
                           {format(new Date(transaction.transaction_at), 'yyyy.MM.dd HH:mm', { locale: ko })}
                         </td>
-                        <td className="py-3 px-2">
-                          <div className="flex items-center gap-1">
+                        <td className="py-3 px-2 text-center">
+                          <div className="flex items-center justify-center gap-1">
                             {getTransactionIcon(transaction.transaction_type)}
                             <span className="text-xs font-medium">
                               {getTransactionTypeName(transaction.transaction_type)}
@@ -465,7 +467,7 @@ const HistoryPage = () => {
                                   슬롯 #{transaction.user_slot_number} 환불
                                 </div>
                               )}
-                              
+
                               {/* 키워드 테이블에서 가져온 경우 */}
                               {transaction.main_keyword ? (
                                 <>
@@ -488,24 +490,24 @@ const HistoryPage = () => {
                                     {(() => {
                                       const inputData = transaction.slot_input_data;
                                       const campaignAddInfo = transaction.campaign_add_info;
-                                      
-                                      
+
+
                                       // 필드 매핑이 있으면 우선순위에 따라 표시
                                       let mainDisplay = '';
                                       const additionalInfo: string[] = [];
-                                      
+
                                       // campaigns.add_info의 add_field 배열 확인
                                       if (campaignAddInfo?.add_field && Array.isArray(campaignAddInfo.add_field) && inputData) {
                                         const addFields = campaignAddInfo.add_field;
-                                        
+
                                         // 첫 번째 필드를 메인 표시로, 나머지는 추가 정보로
                                         addFields.forEach((field: any, index: number) => {
                                           // fieldName이 키임 (예: '항목명 1')
                                           const fieldName = field.fieldName;
                                           const fieldLabel = fieldName; // 간단하게 필드명 사용
                                           const value = inputData[fieldName];
-                                          
-                                          
+
+
                                           if (value && value.toString().trim() !== '') {
                                             if (index === 0) {
                                               mainDisplay = value;
@@ -515,30 +517,30 @@ const HistoryPage = () => {
                                           }
                                         });
                                       }
-                                      
+
                                       // 필드 매핑이 없으면 기존 로직 사용
                                       if (!mainDisplay && inputData) {
-                                        mainDisplay = inputData.productName || 
-                                                     inputData.title || 
-                                                     inputData.main_keyword || 
-                                                     inputData.keyword ||
-                                                     inputData.keywords ||
-                                                     '';
-                                        
+                                        mainDisplay = inputData.productName ||
+                                          inputData.title ||
+                                          inputData.main_keyword ||
+                                          inputData.keyword ||
+                                          inputData.keywords ||
+                                          '';
+
                                         // 여전히 없으면 첫 번째 의미있는 필드
                                         if (!mainDisplay) {
                                           const excludeFields = ['mid', 'url', 'price', 'quantity', 'id', 'created_at', 'updated_at'];
                                           for (const [key, value] of Object.entries(inputData)) {
-                                            if (!excludeFields.includes(key) && 
-                                                typeof value === 'string' && 
-                                                value.trim() !== '') {
+                                            if (!excludeFields.includes(key) &&
+                                              typeof value === 'string' &&
+                                              value.trim() !== '') {
                                               mainDisplay = value;
                                               break;
                                             }
                                           }
                                         }
                                       }
-                                      
+
                                       return (
                                         <>
                                           <div className="text-xs font-medium text-gray-900 truncate">
@@ -550,7 +552,7 @@ const HistoryPage = () => {
                                   </>
                                 ) : null
                               )}
-                              
+
                               {/* 캠페인 정보 */}
                               {transaction.campaign_name && (
                                 <div className="text-xs text-blue-600 mt-1 truncate">
@@ -561,8 +563,8 @@ const HistoryPage = () => {
                           ) : (
                             <>
                               {/* 슬롯 자동 완료 환불 특별 처리 */}
-                              {transaction.transaction_type === 'refund' && 
-                               transaction.description?.includes('슬롯 자동 완료 환불') ? (
+                              {transaction.transaction_type === 'refund' &&
+                                transaction.description?.includes('슬롯 자동 완료 환불') ? (
                                 <div className="truncate">
                                   <div className="text-xs text-orange-600 font-medium">
                                     {transaction.description}
@@ -580,27 +582,27 @@ const HistoryPage = () => {
                         <td className="py-3 px-2 text-right">
                           {formatAmount(transaction.amount, transaction.transaction_type)}
                         </td>
-                        <td className="py-3 px-2">
+                        <td className="py-3 px-2 text-center">
                           {transaction.balance_type && (
                             <Badge variant="outline" className="text-xs">
-                              {transaction.balance_type === 'free' ? '무료' : 
-                               transaction.balance_type === 'paid' ? '유료' : '혼합'}
+                              {transaction.balance_type === 'free' ? '무료' :
+                                transaction.balance_type === 'paid' ? '유료' : '혼합'}
                             </Badge>
                           )}
                         </td>
                         <td className="py-3 px-2 text-center">
-                          {(transaction.is_slot_transaction || 
-                            (transaction.transaction_type === 'refund' && 
-                             transaction.description?.includes('슬롯 자동 완료 환불'))) && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-7 w-7 p-0"
-                              onClick={() => handleOpenDetailModal(transaction)}
-                            >
-                              <Eye className="h-3.5 w-3.5" />
-                            </Button>
-                          )}
+                          {(transaction.is_slot_transaction ||
+                            (transaction.transaction_type === 'refund' &&
+                              transaction.description?.includes('슬롯 자동 완료 환불'))) && (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 w-7 p-0"
+                                onClick={() => handleOpenDetailModal(transaction)}
+                              >
+                                <Eye className="h-3.5 w-3.5" />
+                              </Button>
+                            )}
                         </td>
                       </tr>
                     ))
@@ -627,21 +629,21 @@ const HistoryPage = () => {
                         <div className="text-right">
                           {formatAmount(transaction.amount, transaction.transaction_type)}
                         </div>
-                        {(transaction.is_slot_transaction || 
-                          (transaction.transaction_type === 'refund' && 
-                           transaction.description?.includes('슬롯 자동 완료 환불'))) && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 w-6 p-0"
-                            onClick={() => handleOpenDetailModal(transaction)}
-                          >
-                            <Eye className="h-3 w-3" />
-                          </Button>
-                        )}
+                        {(transaction.is_slot_transaction ||
+                          (transaction.transaction_type === 'refund' &&
+                            transaction.description?.includes('슬롯 자동 완료 환불'))) && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-6 w-6 p-0"
+                              onClick={() => handleOpenDetailModal(transaction)}
+                            >
+                              <Eye className="h-3 w-3" />
+                            </Button>
+                          )}
                       </div>
                     </div>
-                    
+
                     {/* 중단: 구분과 내용 */}
                     <div className="space-y-1">
                       <div className="flex items-center gap-2">
@@ -651,12 +653,12 @@ const HistoryPage = () => {
                         </span>
                         {transaction.balance_type && (
                           <Badge variant="outline" className="text-xs">
-                            {transaction.balance_type === 'free' ? '무료' : 
-                             transaction.balance_type === 'paid' ? '유료' : '혼합'}
+                            {transaction.balance_type === 'free' ? '무료' :
+                              transaction.balance_type === 'paid' ? '유료' : '혼합'}
                           </Badge>
                         )}
                       </div>
-                      
+
                       {/* 내용 표시 */}
                       <div className="text-sm text-gray-600">
                         {transaction.is_slot_transaction ? (
@@ -667,7 +669,7 @@ const HistoryPage = () => {
                                 슬롯 #{transaction.user_slot_number} 환불
                               </div>
                             )}
-                            
+
                             {/* 키워드 정보 또는 슬롯 정보 표시 로직 */}
                             {transaction.main_keyword ? (
                               <>
@@ -692,8 +694,8 @@ const HistoryPage = () => {
                         ) : (
                           <>
                             {/* 슬롯 자동 완료 환불 특별 처리 */}
-                            {transaction.transaction_type === 'refund' && 
-                             transaction.description?.includes('슬롯 자동 완료 환불') ? (
+                            {transaction.transaction_type === 'refund' &&
+                              transaction.description?.includes('슬롯 자동 완료 환불') ? (
                               <div>
                                 <div className="text-xs text-orange-600 font-medium">
                                   {transaction.description}
@@ -743,14 +745,14 @@ const HistoryPage = () => {
           </CardContent>
         </Card>
       </div>
-      
+
       {/* 상세보기 모달 */}
       <Dialog open={!!selectedTransaction} onOpenChange={(open) => !open && setSelectedTransaction(null)}>
         <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
           <DialogHeader>
             <DialogTitle>거래 상세 정보</DialogTitle>
           </DialogHeader>
-          
+
           {selectedTransaction && (
             <div className="overflow-y-auto flex-1 px-6 pb-6">
               <div className="space-y-4">
@@ -769,7 +771,7 @@ const HistoryPage = () => {
                     <p className="text-sm font-medium">{formatAmount(selectedTransaction.amount, selectedTransaction.transaction_type)}</p>
                   </div>
                 </div>
-                
+
                 {/* 슬롯 정보 */}
                 {selectedTransaction.is_slot_transaction && (
                   <>
@@ -795,7 +797,7 @@ const HistoryPage = () => {
                             <div className="mb-2">
                               <p className="text-xs text-gray-500">원래 작업 기간</p>
                               <p className="text-sm">
-                                {format(new Date(selectedTransaction.slot_start_date), 'yyyy.MM.dd', { locale: ko })} ~ 
+                                {format(new Date(selectedTransaction.slot_start_date), 'yyyy.MM.dd', { locale: ko })} ~
                                 {format(new Date(selectedTransaction.slot_end_date), 'yyyy.MM.dd', { locale: ko })}
                               </p>
                             </div>
@@ -811,71 +813,71 @@ const HistoryPage = () => {
                     </div>
                   </>
                 )}
-                
+
                 {/* 자동 완료 환불 정보 */}
-                {selectedTransaction.transaction_type === 'refund' && 
-                 selectedTransaction.description?.includes('슬롯 자동 완료 환불') && (
-                  <>
-                    <hr />
-                    <div>
-                      <h4 className="text-sm font-medium mb-2">자동 환불 정보</h4>
-                      <div className="mb-2">
-                        <p className="text-xs text-gray-500">환불 유형</p>
-                        <p className="text-sm">시스템 자동 환불</p>
-                      </div>
-                      <div className="mb-2">
-                        <p className="text-xs text-gray-500">설명</p>
-                        <p className="text-sm">{selectedTransaction.description}</p>
-                      </div>
-                      {selectedTransaction.reference_id && (
+                {selectedTransaction.transaction_type === 'refund' &&
+                  selectedTransaction.description?.includes('슬롯 자동 완료 환불') && (
+                    <>
+                      <hr />
+                      <div>
+                        <h4 className="text-sm font-medium mb-2">자동 환불 정보</h4>
                         <div className="mb-2">
-                          <p className="text-xs text-gray-500">참조 ID</p>
-                          <p className="text-sm text-gray-600">{selectedTransaction.reference_id}</p>
+                          <p className="text-xs text-gray-500">환불 유형</p>
+                          <p className="text-sm">시스템 자동 환불</p>
                         </div>
-                      )}
-                      
-                      {/* 자동 환불 관련 슬롯 목록 */}
-                      {autoRefundSlots.length > 0 && (
                         <div className="mb-2">
-                          <p className="text-xs text-gray-500">환불된 슬롯 ({autoRefundSlots.length}개)</p>
-                          <div className="space-y-2 mt-1">
-                            {autoRefundSlots.map((slot, index) => (
-                              <div key={slot.id} className="bg-white p-3 rounded border text-sm">
-                                <div className="flex justify-between items-start mb-1">
-                                  <span className="font-medium">슬롯 #{slot.user_slot_number}</span>
-                                  <span className="text-xs text-gray-500">
-                                    {format(new Date(slot.processed_at), 'MM/dd HH:mm', { locale: ko })}
-                                  </span>
-                                </div>
-                                {slot.campaigns && (
-                                  <div className="text-xs text-blue-600">
-                                    {slot.campaigns.campaign_name} - {SERVICE_TYPE_LABELS[slot.campaigns.service_type as keyof typeof SERVICE_TYPE_LABELS] || slot.campaigns.service_type}
-                                  </div>
-                                )}
-                                {slot.keywords?.main_keyword && (
-                                  <div className="text-xs text-gray-600 mt-1">
-                                    키워드: {slot.keywords.main_keyword}
-                                    {(slot.keywords.keyword1 || slot.keywords.keyword2 || slot.keywords.keyword3) && (
-                                      <span className="text-gray-500">
-                                        {' '}+ {[slot.keywords.keyword1, slot.keywords.keyword2, slot.keywords.keyword3].filter(Boolean).length}개
-                                      </span>
-                                    )}
-                                  </div>
-                                )}
-                                {slot.start_date && slot.end_date && (
-                                  <div className="text-xs text-gray-500 mt-1">
-                                    작업기간: {format(new Date(slot.start_date), 'MM/dd', { locale: ko })} ~ {format(new Date(slot.end_date), 'MM/dd', { locale: ko })}
-                                  </div>
-                                )}
-                              </div>
-                            ))}
+                          <p className="text-xs text-gray-500">설명</p>
+                          <p className="text-sm">{selectedTransaction.description}</p>
+                        </div>
+                        {selectedTransaction.reference_id && (
+                          <div className="mb-2">
+                            <p className="text-xs text-gray-500">참조 ID</p>
+                            <p className="text-sm text-gray-600">{selectedTransaction.reference_id}</p>
                           </div>
-                        </div>
-                      )}
-                    </div>
-                  </>
-                )}
-                
+                        )}
+
+                        {/* 자동 환불 관련 슬롯 목록 */}
+                        {autoRefundSlots.length > 0 && (
+                          <div className="mb-2">
+                            <p className="text-xs text-gray-500">환불된 슬롯 ({autoRefundSlots.length}개)</p>
+                            <div className="space-y-2 mt-1">
+                              {autoRefundSlots.map((slot, index) => (
+                                <div key={slot.id} className="bg-white p-3 rounded border text-sm">
+                                  <div className="flex justify-between items-start mb-1">
+                                    <span className="font-medium">슬롯 #{slot.user_slot_number}</span>
+                                    <span className="text-xs text-gray-500">
+                                      {format(new Date(slot.processed_at), 'MM/dd HH:mm', { locale: ko })}
+                                    </span>
+                                  </div>
+                                  {slot.campaigns && (
+                                    <div className="text-xs text-blue-600">
+                                      {slot.campaigns.campaign_name} - {SERVICE_TYPE_LABELS[slot.campaigns.service_type as keyof typeof SERVICE_TYPE_LABELS] || slot.campaigns.service_type}
+                                    </div>
+                                  )}
+                                  {slot.keywords?.main_keyword && (
+                                    <div className="text-xs text-gray-600 mt-1">
+                                      키워드: {slot.keywords.main_keyword}
+                                      {(slot.keywords.keyword1 || slot.keywords.keyword2 || slot.keywords.keyword3) && (
+                                        <span className="text-gray-500">
+                                          {' '}+ {[slot.keywords.keyword1, slot.keywords.keyword2, slot.keywords.keyword3].filter(Boolean).length}개
+                                        </span>
+                                      )}
+                                    </div>
+                                  )}
+                                  {slot.start_date && slot.end_date && (
+                                    <div className="text-xs text-gray-500 mt-1">
+                                      작업기간: {format(new Date(slot.start_date), 'MM/dd', { locale: ko })} ~ {format(new Date(slot.end_date), 'MM/dd', { locale: ko })}
+                                    </div>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  )}
+
                 {/* 추가 입력 필드 정보 */}
                 {selectedTransaction.slot_input_data && (
                   <>
@@ -886,10 +888,10 @@ const HistoryPage = () => {
                         {(() => {
                           const inputData = selectedTransaction.slot_input_data;
                           const campaignAddInfo = selectedTransaction.campaign_add_info;
-                          
+
                           // 표시할 필드들을 정리
                           const fieldsToDisplay: { label: string; value: any }[] = [];
-                          
+
                           // 슬롯 승인 페이지처럼 제외할 필드들 정의
                           const excludeFields = [
                             // 시스템 필드
@@ -907,7 +909,7 @@ const HistoryPage = () => {
                             'is_manual_input', 'dueDays', 'expected_deadline',
                             'workCount', 'quantity'
                           ];
-                          
+
                           // 필드명 한글 매핑
                           const fieldNameMap: Record<string, string> = {
                             'productName': '상품명',
@@ -919,70 +921,70 @@ const HistoryPage = () => {
                             'description': '설명',
                             'content': '내용'
                           };
-                          
+
                           // campaign add_field가 있으면 그것을 우선 사용
                           if (campaignAddInfo?.add_field && Array.isArray(campaignAddInfo.add_field)) {
                             campaignAddInfo.add_field.forEach((field: any) => {
                               const fieldName = field.fieldName;
                               const value = inputData[fieldName];
-                              
+
                               // 빈 값이거나 빈 객체인 경우 제외
-                              if (value === undefined || value === null || value === '' || 
-                                  (typeof value === 'object' && Object.keys(value).length === 0)) {
+                              if (value === undefined || value === null || value === '' ||
+                                (typeof value === 'object' && Object.keys(value).length === 0)) {
                                 return;
                               }
-                              
+
                               // 이미지 필드인지 확인
-                              const isImage = field.type === 'image' || 
-                                            (typeof value === 'string' && 
-                                             value.match(/^https?:\/\/.*\.(jpg|jpeg|png|gif|webp)$/i));
-                              
+                              const isImage = field.type === 'image' ||
+                                (typeof value === 'string' &&
+                                  value.match(/^https?:\/\/.*\.(jpg|jpeg|png|gif|webp)$/i));
+
                               fieldsToDisplay.push({
                                 label: field.fieldLabel || fieldName,
                                 value: isImage ? { type: 'image', url: value } : value
                               });
                             });
                           }
-                          
+
                           // add_field에 없는 나머지 필드들 중 중요한 것만 표시
                           if (inputData) {
                             const displayedFields = campaignAddInfo?.add_field?.map((f: any) => f.fieldName) || [];
-                            
+
                             // 표시할 만한 중요 필드들
                             const importantFields = ['title', 'productName', 'keyword', 'keywords', 'main_keyword', 'url', 'link'];
-                            
+
                             Object.entries(inputData).forEach(([key, value]) => {
                               // 제외할 필드인 경우 스킵
                               if (excludeFields.includes(key) || displayedFields.includes(key)) {
                                 return;
                               }
-                              
+
                               // 파일 관련 필드는 제외 (_fileName, _file로 끝나는 필드)
                               if (key.endsWith('_fileName') || key.endsWith('_file')) {
                                 return;
                               }
-                              
+
                               // 빈 값이거나 빈 객체인 경우 제외
-                              if (value === undefined || value === null || value === '' || 
-                                  (typeof value === 'object' && Object.keys(value).length === 0)) {
+                              if (value === undefined || value === null || value === '' ||
+                                (typeof value === 'object' && Object.keys(value).length === 0)) {
                                 return;
                               }
-                              
+
                               // URL인지 확인
                               const isUrl = typeof value === 'string' && value.match(/^https?:\/\//);
                               const isImage = isUrl && value.match(/\.(jpg|jpeg|png|gif|webp)$/i);
-                              
+
                               // 필드명 변환 (한글 매핑이 있으면 사용, 없으면 원본 사용)
                               const displayLabel = fieldNameMap[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
-                              
+
                               fieldsToDisplay.push({
                                 label: displayLabel,
-                                value: isImage ? { type: 'image', url: value } : 
-                                      isUrl ? { type: 'url', url: value } : value
+                                value: isImage ? { type: 'image', url: value } :
+                                  isUrl ? { type: 'url', url: value } : value
                               });
                             });
                           }
-                          
+
                           // 필드가 없으면 원본 JSON 표시
                           if (fieldsToDisplay.length === 0) {
                             return (
@@ -993,20 +995,20 @@ const HistoryPage = () => {
                               </div>
                             );
                           }
-                          
+
                           // 필드별로 이쁘게 표시
                           return fieldsToDisplay.map((field, index) => (
                             <div key={index} className="bg-gray-50 p-4 rounded-lg">
                               <p className="text-xs font-medium text-gray-700 mb-2">{field.label}</p>
                               {field.value?.type === 'image' ? (
-                                <img 
-                                  src={field.value.url} 
+                                <img
+                                  src={field.value.url}
                                   alt={field.label}
                                   className="max-w-full h-auto rounded-md shadow-sm"
                                   style={{ maxHeight: '200px', objectFit: 'contain' }}
                                 />
                               ) : field.value?.type === 'url' ? (
-                                <a 
+                                <a
                                   href={field.value.url}
                                   target="_blank"
                                   rel="noopener noreferrer"
@@ -1016,8 +1018,8 @@ const HistoryPage = () => {
                                 </a>
                               ) : (
                                 <p className="text-gray-800">
-                                  {typeof field.value === 'object' && field.value !== null ? 
-                                    JSON.stringify(field.value, null, 2) : 
+                                  {typeof field.value === 'object' && field.value !== null ?
+                                    JSON.stringify(field.value, null, 2) :
                                     String(field.value)
                                   }
                                 </p>
@@ -1034,7 +1036,7 @@ const HistoryPage = () => {
           )}
         </DialogContent>
       </Dialog>
-    </Container>
+    </CommonTemplate>
   );
 };
 

--- a/src/pages/distributor/refund-management/RefundManagementPage.tsx
+++ b/src/pages/distributor/refund-management/RefundManagementPage.tsx
@@ -107,7 +107,6 @@ const RefundManagementPage: React.FC = () => {
       const { data, error } = await query;
 
       if (error) {
-        console.error('Error details:', error);
         if (error.code === '42P01') {
           // 테이블이 존재하지 않는 경우
           showError('환불 요청 테이블이 아직 생성되지 않았습니다. 관리자에게 문의해주세요.');
@@ -121,9 +120,7 @@ const RefundManagementPage: React.FC = () => {
         request.slot?.mat_id === currentUser.id
       );
       setRefundRequests(filteredData);
-      console.log('Fetched refund requests:', filteredData);
     } catch (error) {
-      console.error('Error fetching refund requests:', error);
       showError('환불 요청 목록을 불러오는데 실패했습니다.');
     } finally {
       setIsLoading(false);
@@ -264,7 +261,9 @@ const RefundManagementPage: React.FC = () => {
             status: 'pending'
           });
 
-        if (scheduleError) console.error('Error creating refund schedule:', scheduleError);
+        if (scheduleError) {
+          // 스케줄 생성 실패는 조용히 처리 (메인 프로세스에는 영향 없음)
+        }
       }
       
       // 환불 차액이 있으면 총판에게 캐시 지급
@@ -306,12 +305,11 @@ const RefundManagementPage: React.FC = () => {
             });
           
           if (historyError) {
-            console.error('Error creating cash history:', historyError);
+            // 캐시 히스토리 생성 실패는 조용히 처리
           }
           
           showSuccess(`환불 요청이 승인되었습니다.\n환불 차액 ${refundDifference.toLocaleString()}원이 총판에게 지급되었습니다.`);
         } catch (error) {
-          console.error('Error updating distributor balance:', error);
           showSuccess('환불 요청이 승인되었습니다.\n(차액 지급 중 오류가 발생했습니다)');
         }
       } else {
@@ -324,7 +322,6 @@ const RefundManagementPage: React.FC = () => {
       setApprovalReason('');
       fetchRefundRequests();
     } catch (error) {
-      console.error('Error approving refund:', error);
       showError('환불 승인 중 오류가 발생했습니다.');
     } finally {
       setIsLoading(false);
@@ -366,7 +363,6 @@ const RefundManagementPage: React.FC = () => {
       setRejectionReason('');
       fetchRefundRequests();
     } catch (error) {
-      console.error('Error rejecting refund:', error);
       showError('환불 거절 중 오류가 발생했습니다.');
     } finally {
       setIsLoading(false);

--- a/src/pages/withdraw/components/WithdrawHistory.tsx
+++ b/src/pages/withdraw/components/WithdrawHistory.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { WithdrawRequest, getRecentWithdrawRequests } from '../services/withdrawService';
+import { useNavigate } from 'react-router-dom';
 
 interface WithdrawHistoryProps {
   userId: string;
@@ -9,6 +10,7 @@ interface WithdrawHistoryProps {
 const WithdrawHistory: React.FC<WithdrawHistoryProps> = ({ userId, refreshTrigger }) => {
   const [recentRequests, setRecentRequests] = useState<WithdrawRequest[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const navigate = useNavigate();
   
   // 날짜 포맷팅 함수
   const formatDate = (dateString: string) => {
@@ -54,7 +56,7 @@ const WithdrawHistory: React.FC<WithdrawHistoryProps> = ({ userId, refreshTrigge
     setIsLoading(true);
     
     try {
-      const data = await getRecentWithdrawRequests(userId);
+      const data = await getRecentWithdrawRequests(userId, 3);
       setRecentRequests(data);
     } catch (err) {
       
@@ -73,8 +75,18 @@ const WithdrawHistory: React.FC<WithdrawHistoryProps> = ({ userId, refreshTrigge
 
   return (
     <div className="mb-8 pt-10">
-      <div className="mb-3">
-        <p className="text-sm font-medium">최근 출금 요청 내역</p>
+      <div className="mb-3 flex justify-between items-center">
+        <p className="text-sm font-medium">최근 출금 요청 내역 (최근 3건)</p>
+        <button
+          type="button"
+          className="text-xs text-primary hover:text-primary-dark hover:underline flex items-center gap-1 bg-transparent border-0 p-0 cursor-pointer"
+          onClick={() => navigate('/cash/history')}
+        >
+          <span>상세보기</span>
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
       </div>
       
       {isLoading ? (


### PR DESCRIPTION
1. 최초 가입 시 광고주 권한 적용
2. 회원가입 시 회원가입이 완료되었습니다. 안내 메세지 및 toast 메시지 추가
3. 효과 및 사용법 다크모드 적용
4. 슬롯 구매 모달 수정
 - 내키워드 메뉴 제거로 인한 keywordFields 임시 주석 처리, service_keyword_field_mappings 를 통한 매핑 테이블 제외
 - 기본 작업 카운트와 작업일만 남겨두고, 캠페인에서 정의한 추가 필드만 표기하도록 함.
5. 캐시 충전 모달 및 캐시 출금 신청 페이지 수정 : 최근 내역에 최대 3건만 표기, 상세보기 버튼으로 캐시 충전/사용내역 페이지로 이동
6. 캠페인 신청 폼 수정 : 캠페인폼 라벨쪽과 환불쪽 클래스 일치화 및 th width 고정
7. 일반형 슬롯 구매 신청 시 총판 알림 추가
8. 일반형 슬롯 관리 페이지, 보장형 슬롯 관리 페이지 수정
 - 검색 조건의 서비스 타입에 전체 서비스 추가 및 메뉴 순서 적용, 자기 캠페인만 볼 수 있도록 추가